### PR TITLE
Adding interest on debt

### DIFF
--- a/Colombia/transform_load_raw_dlt.py
+++ b/Colombia/transform_load_raw_dlt.py
@@ -513,7 +513,9 @@ def col_central_boost_silver_from_raw():
         ) & ~col("pension")), "Goods and services"
       ).when(
         (col("subsidy") & ~col("pension")), "Subsidies"
-      ).otherwise( # Colombia has no "Other grants and transfers"
+      ).when(
+        lower(col('econ2')).startswith("servicio") & ~col('econ1').contains('Adquisición de Activos Financieros'), 'Interest on debt'
+        ).otherwise( # Colombia has no "Other grants and transfers"
         lit("Other expenses")
       )
     )
@@ -537,6 +539,8 @@ def col_subnat_boost_silver_from_raw():
                 col("econ2").isin('ADQUISICIÓN DE BIENES', 'ADQUISICIÓN DE SERVICIOS', 'ADQUISICION DE BIENES Y SERVICIOS'), 'Goods and services'
             ).when(
                 col("econ2") == 'TRANSFERENCIAS DE CAPITAL', 'Capital expenditures'
+            ).when(
+                lower(col('econ2')).startswith("servicio") & ~col('econ1').contains('Adquisición de Activos Financieros'), 'Interest on debt'
             ).otherwise(
                 lit("Other expenses")
             )

--- a/Colombia/transform_load_raw_dlt.py
+++ b/Colombia/transform_load_raw_dlt.py
@@ -436,7 +436,7 @@ def col_central_gold():
 @dlt.table(name=f'col_central_boost_silver_from_raw')
 def col_central_boost_silver_from_raw():
   return (dlt.read('col_central_gold')
-    .filter(~(col('econ2') == "Adquisición de Activos Financieros"))
+    .filter(~(lower(col('econ2')) == "adquisición de activos financieros"))
     .filter(~col('econ3').startswith('03-03-05-001') & ~col('econ3').startswith('03-03-05-002'))
     .withColumn('pension',
       upper(col("func1")).like('%PENSIONES%') | upper(col("econ3")).like('%(DE PENSIONES)%')
@@ -514,7 +514,7 @@ def col_central_boost_silver_from_raw():
       ).when(
         (col("subsidy") & ~col("pension")), "Subsidies"
       ).when(
-        lower(col('econ2')).startswith("servicio") & ~col('econ1').contains('Adquisición de Activos Financieros'), 'Interest on debt'
+        lower(col('econ2')).startswith("servicio"), 'Interest on debt'
         ).otherwise( # Colombia has no "Other grants and transfers"
         lit("Other expenses")
       )
@@ -528,6 +528,7 @@ def col_central_boost_silver_from_raw():
 @dlt.table(name=f'col_subnat_boost_silver_from_raw')
 def col_subnat_boost_silver_from_raw():
     return (dlt.read('col_subnat_gold')
+        .filter(~(lower(col('econ2')) == "adquisición de activos financieros"))
         .withColumn("func",
             when(col("func1") == "Pensions", lit("Social protection"))
             .otherwise(col("func1"))
@@ -540,7 +541,7 @@ def col_subnat_boost_silver_from_raw():
             ).when(
                 col("econ2") == 'TRANSFERENCIAS DE CAPITAL', 'Capital expenditures'
             ).when(
-                lower(col('econ2')).startswith("servicio") & ~col('econ1').contains('Adquisición de Activos Financieros'), 'Interest on debt'
+                lower(col('econ2')).startswith("servicio"), 'Interest on debt'
             ).otherwise(
                 lit("Other expenses")
             )


### PR DESCRIPTION
The corresponding Excel command is
`=SUMIFS(executed,econ1,"<>Adquisición de Activos Financieros",year,Q$1,econ2,"servicio*")`

I could confirm that the values reproduced from _boost_intermediate.col_central_boost_silver_
<details><summary>Code run to check</summary>

```
import dlt
from pyspark.sql.functions import substring, col, lit, when, element_at,\
  split, upper, length, lead, expr, trim, lpad, concat, concat_ws, last,\
  coalesce, size, count, sum, lower
from pyspark.sql.window import Window
from pyspark.sql.types import IntegerType

df=spark.sql("select * from boost_intermediate.col_central_boost_silver")
new = df.withColumn("func",
            when(col("func1") == "Pensions", lit("Social protection"))
            .otherwise(col("func1"))
        ).withColumn("econ",
        when(
            col("econ2") == 'GASTOS DE PERSONAL', 'Wage bill'
        ).when(
            col("econ2").isin('ADQUISICIÓN DE BIENES', 'ADQUISICIÓN DE SERVICIOS', 'ADQUISICION DE BIENES Y SERVICIOS'), 'Goods and services'
        ).when(
            col("econ2") == 'TRANSFERENCIAS DE CAPITAL', 'Capital expenditures'
        ).when(
            lower(col('econ2')).startswith("servicio") & ~col('econ1').contains('Adquisición de Activos Financieros'), 'Interest on debt'
        ).otherwise(
            lit("Other expenses")
        )
    )
        
spark.read("")
selected = new[(new.econ == 'Interest on debt') & (new.year == 2019)]
selected.select(sum(selected["Pago"])).show()
```

</details> 

However, there are some discrepancies when running from the pipelien on _col_central_boost_silver_from_raw_

@weilu 
I rememeber that you mentioned that we don't have to take care of discrepancies for Colombia for now. But let me know if you want me to dig into this at this point for this PR.