### PR TITLE
Discrepancy func for burkina faso

### DIFF
--- a/Burkina_Faso/BFA_transform_load_dlt.py
+++ b/Burkina_Faso/BFA_transform_load_dlt.py
@@ -108,7 +108,8 @@ def boost_silver():
         .when((col('YEAR') < 2017) & (col('FUNCTION2').startswith('092')), 'secondary education')
     ).withColumn(
         'func',
-        when(col('FUNCTION1').startswith('02'), 'Defence')
+        when(col('YEAR') == 2016, lit(None)) # Remove 2016 entirely from func calculation as wage bill is missing
+        .when(col('FUNCTION1').startswith('02'), 'Defence')
         .when(col('func_sub').isin('judiciary', 'public safety'), 'Public order and safety')
         .when(col('FUNCTION1').startswith('04'), 'Economic affairs')
         .when(col('FUNCTION1').startswith('05'), 'Environmental protection')


### PR DESCRIPTION
The current discrepancy in func is due to not removing 2016 from the func calculation. 
The excel sheet explicitly removes the formula for 2016. Massimo also advises to remove the year from the calculation entirely for func. 
https://docs.google.com/document/d/10wdHD5x2IYw6VC-savb2TcC7y1adIPle2dMKOE0D7sI/edit#heading=h.sonwwcysybzo.

After this change, there should not be any discrepancies remanining for func of Burkina Faso 2016.