### PR TITLE
Uruguay discrepancy fix

### DIFF
--- a/Uruguay/URY_transform_load_dlt.py.py
+++ b/Uruguay/URY_transform_load_dlt.py.py
@@ -1,15 +1,26 @@
 # Databricks notebook source
 import dlt
 import unicodedata
-from pyspark.sql.functions import substring, col, lit, when, udf, trim, regexp_replace, initcap, concat,lower
+from pyspark.sql.functions import (
+    substring,
+    col,
+    lit,
+    when,
+    udf,
+    trim,
+    regexp_replace,
+    initcap,
+    concat,
+    lower,
+)
 from pyspark.sql.types import StringType
 
 # Note DLT requires the path to not start with /dbfs
 TOP_DIR = "/mnt/DAP/data/BOOSTProcessed"
 INPUT_DIR = f"{TOP_DIR}/Documents/input/Countries"
 WORKSPACE_DIR = f"{TOP_DIR}/Workspace"
-COUNTRY = 'Uruguay'
-COUNTRY_MICRODATA_DIR = f'{WORKSPACE_DIR}/microdata_csv/{COUNTRY}'
+COUNTRY = "Uruguay"
+COUNTRY_MICRODATA_DIR = f"{WORKSPACE_DIR}/microdata_csv/{COUNTRY}"
 
 CSV_READ_OPTIONS = {
     "header": "true",
@@ -18,90 +29,276 @@ CSV_READ_OPTIONS = {
     "escape": '"',
 }
 
+
 @dlt.expect_or_drop("year_not_null", "YEAR IS NOT NULL")
-@dlt.table(name=f'ury_boost_bronze')
+@dlt.table(name=f"ury_boost_bronze")
 def boost_bronze():
     # Load the data from CSV
-    return (spark.read
-            .format("csv")
-            .options(**CSV_READ_OPTIONS)
-            .option("inferSchema", "true")
-            .load(f'{COUNTRY_MICRODATA_DIR}')
+    return (
+        spark.read.format("csv")
+        .options(**CSV_READ_OPTIONS)
+        .option("inferSchema", "true")
+        .load(f"{COUNTRY_MICRODATA_DIR}")
     )
 
-@dlt.table(name=f'ury_boost_silver')
+
+@dlt.table(name=f"ury_boost_silver")
 def boost_silver():
-    return (dlt.read(f'ury_boost_bronze')
-            .withColumn('admin0', lit('Central')) # No subnational data available
-            .withColumn('geo1', lit('Central')) # No subnational data available
-            .withColumn('is_foreign', col('SOURCE_FIN1').startswith('20 '))
-            .withColumn('func_sub',
-                        when(col('func1').startswith('01 '), 'judiciary')
-                        .when(col('func1').startswith('14 '), 'public safety')
-                        .when(col("admin1").startswith("07 "), 'agriculture')
-                        .when(col('func1').startswith('09 ') & ~col('func2').startswith("0368 ") & ~col('func2').startswith("0369 "), "transport" )
-                        .when(col('func1').startswith('09 ') & (col('project1').startswith('24.0366.922 ') | col('project1').startswith('922 ')), 'road transport')
-                        .when(col('func1').startswith('09 ') & col('func2').startswith('0367 '), 'air transport')
-                        .when(col('func1').startswith('09 ') & col('func2').startswith('0369 '), 'telecom')
-                        .when(col('func1').startswith('09 ') & col('func2').startswith('0368 '), 'energy')
-                        .when(col('func1').startswith('08 ') & col('func2').startswith('0002 '), 'primary education')
-                        .when(col('func1').startswith('08 ') & col('func2').startswith('0003 '), 'secondary education')
-                        .when(col('func1').startswith('08 ') & 
-                              (col('func2').startswith('0351 ') | col('func2').startswith('0347 ') | col('func2').startswith('0349 ') | col('func2').startswith('0353 ')), 'tertiary education')
-                        )
-            .withColumn('func', 
-                        when(col("func1").startswith('06 '), 'Defence')
-                        .when(col('func_sub').isin('judiciary', 'public safety'), 'Public order and safety')
-                        .when( (col('year') <= 2017) & (col('func1').startswith('03 ') | col('func1').startswith("07 ")| col('func1').startswith("16 ")|col("func1").startswith("09 ")| col("func1").startswith("18 ")), "Economic affairs")
-                        .when(((col("year") > 2017) & ((col('func1').startswith("07 "))| (col('func1').startswith("16 "))| (col("func1").startswith("09 "))| (col("func1").startswith("18 ")))), "Economic affairs")
-                        .when(col('func1').startswith('10 '), 'Environmental protection')
-                        .when(col('func1').startswith('17 '), 'Housing and community amenities')
-                        .when(col('func1').startswith('13 '), "Health")
-                        .when(col('func1').startswith('05 '), "Recreation, culture and religion")
-                        .when(col('func1').startswith('08 '), 'Education')
-                        .when(col('func1').startswith('11 '), 'Social protection')
-                        .otherwise('General public services'))
-            .withColumn('econ_sub',
-                        when((col('exp_type') == "Personal") & (lower(col('econ2')) != '06 beneficios al personal') & (lower(col('econ2')) != '07 beneficios familiares') & ( lower(col('econ2')) != '08 cargas legales sobre servicios personales'), 'basic wages')
-                        .when(col('exp_type') == "Personal", "allowances")
-                        .when((col('exp_type')=="Inversion") & col('source_fin1').startswith('20 '), 'capital expenditure (foreign spending)')
-                        .when(lower(col('econ2')) == '21 servicios basicos', 'basic services')
-                        .when(lower(col('econ2')) == '28 servicios tecnicos, profesionales y artisticos(dec.17/003)', 'employment contracts')
-                        .when(lower(col('econ2')) == '27 serv. para mant., reparaciones menores y limpieza', 'recurrent maintenance')
-                        .when(((col("year") < 2020) & (lower(col('econ2')) == '52 transferencias corrientes al sector privado') | (lower(col('econ2')) == '54 transferencias de capital al sector privado') | (lower(col('econ2')) == '04 transferencias de capital al sector privado') | (lower(col('econ2')) == '02 transferencias corrientes al sector privado')), 'subsidies to production')
-                        .when((col("year") >= 2020) & ((lower(col('econ2')) == '04 transferencias de capital al sector privado') | (lower(col('econ2')) == '02 transferencias corrientes al sector privado')), 'subsidies to production')
-                        .when(col('func1').startswith('11 ') & col('func2').startswith('0402') & col('econ1').startswith('5 '), 'pensions')
-                        .when(col('func1').startswith('11 ') & col('econ1').startswith('5 '), 'social assistance'))
-            .withColumn('econ',
-                        when(col('econ1').startswith('6 '),'Interest on debt')
-                        .when(col('exp_type') == 'Personal', 'Wage bill')
-                        .when(col('exp_type') == 'Inversion','Capital expenditures')
-                        .when(col('econ1').startswith('1 ') | col('econ1').startswith('2 ')| ((col('econ1').startswith('3 ')) &
-                        (col('exp_type')=="Inversion")),'Goods and services')
-                        .when(((col("year") < 2020) & (lower(col('econ2')) == '52 transferencias corrientes al sector privado') | (lower(col('econ2')) == '54 transferencias de capital al sector privado' ) | (lower(col('econ2')) == '04 transferencias de capital al sector privado') | (lower(col('econ2')) == '02 transferencias corrientes al sector privado')), 'Subsidies')
-                        .when(((col("year") >= 2020) & ((lower(col('econ2'))== '04 transferencias de capital al sector privado') | (lower(col('econ2')) == '02 transferencias corrientes al sector privado'))), 'Subsidies')
-                        .when(col('econ_sub').isin('pensions', 'social assistance'), 'Social benefits')
-                        .when((lower(col('econ2')) == '01 transferencias corrientes al sector publico') | (lower(col('econ2')) == '51 transferencias corrientes al sector publico') & ~col('func1').startswith('11 '), 'Grants and transfers')
-                        .otherwise('Other expenses'))
+    return (
+        dlt.read(f"ury_boost_bronze")
+        .withColumn("admin0", lit("Central"))  # No subnational data available
+        .withColumn("geo1", lit("Central"))  # No subnational data available
+        .withColumn("is_foreign", col("SOURCE_FIN1").startswith("20 "))
+        .withColumn(
+            "func_sub",
+            when(col("func1").startswith("01 "), "judiciary")
+            .when(col("func1").startswith("14 "), "public safety")
+            .when(col("admin1").startswith("07 "), "agriculture")
+            .when(
+                col("func1").startswith("09 ")
+                & ~col("func2").startswith("0368 ")
+                & ~col("func2").startswith("0369 "),
+                "transport",
             )
-
-                        
-@dlt.table(name=f'ury_boost_gold')
-def boost_gold():
-    return (dlt.read(f'ury_boost_silver')
-        .withColumn('country_name', lit(COUNTRY))
-        .select('country_name',
-                'year',
-                'approved',
-                'executed',
-                'is_foreign',
-                'geo1',
-                'admin0',
-                'admin1',
-                'admin2',
-                'func_sub',
-                'func',
-                'econ_sub',
-                'econ')
+            .when(
+                col("func1").startswith("09 ")
+                & (
+                    col("project1").startswith("24.0366.922 ")
+                    | col("project1").startswith("922 ")
+                ),
+                "road transport",
+            )
+            .when(
+                col("func1").startswith("09 ") & col("func2").startswith("0367 "),
+                "air transport",
+            )
+            .when(
+                col("func1").startswith("09 ") & col("func2").startswith("0369 "),
+                "telecom",
+            )
+            .when(
+                col("func1").startswith("09 ") & col("func2").startswith("0368 "),
+                "energy",
+            )
+            .when(
+                col("func1").startswith("08 ") & col("func2").startswith("0002 "),
+                "primary education",
+            )
+            .when(
+                col("func1").startswith("08 ") & col("func2").startswith("0003 "),
+                "secondary education",
+            )
+            .when(
+                col("func1").startswith("08 ")
+                & (
+                    col("func2").startswith("0351 ")
+                    | col("func2").startswith("0347 ")
+                    | col("func2").startswith("0349 ")
+                    | col("func2").startswith("0353 ")
+                ),
+                "tertiary education",
+            ),
+        )
+        .withColumn(
+            "func",
+            when(col("func1").startswith("06 "), "Defence")
+            .when(
+                col("func_sub").isin("judiciary", "public safety"),
+                "Public order and safety",
+            )
+            .when(
+                (col("year") <= 2017)
+                & (
+                    col("func1").startswith("03 ")
+                    | col("func1").startswith("07 ")
+                    | col("func1").startswith("16 ")
+                    | col("func1").startswith("09 ")
+                    | col("func1").startswith("18 ")
+                ),
+                "Economic affairs",
+            )
+            .when(
+                (
+                    (col("year") > 2017)
+                    & (
+                        (col("func1").startswith("07 "))
+                        | (col("func1").startswith("16 "))
+                        | (col("func1").startswith("09 "))
+                        | (col("func1").startswith("18 "))
+                    )
+                ),
+                "Economic affairs",
+            )
+            .when(col("func1").startswith("10 "), "Environmental protection")
+            .when(col("func1").startswith("17 "), "Housing and community amenities")
+            .when(col("func1").startswith("13 "), "Health")
+            .when(col("func1").startswith("05 "), "Recreation, culture and religion")
+            .when(col("func1").startswith("08 "), "Education")
+            .when(col("func1").startswith("11 "), "Social protection")
+            .otherwise("General public services"),
+        )
+        .withColumn(
+            "econ_sub",
+            when(
+                (col("exp_type") == "Personal")
+                & (lower(col("econ2")) != "06 beneficios al personal")
+                & (lower(col("econ2")) != "07 beneficios familiares")
+                & (
+                    lower(col("econ2"))
+                    != "08 cargas legales sobre servicios personales"
+                ),
+                "basic wages",
+            )
+            .when(col("exp_type") == "Personal", "allowances")
+            .when(
+                (col("exp_type") == "Inversion") & col("source_fin1").startswith("20 "),
+                "capital expenditure (foreign spending)",
+            )
+            .when(lower(col("econ2")) == "21 servicios basicos", "basic services")
+            .when(
+                lower(col("econ2"))
+                == "28 servicios tecnicos, profesionales y artisticos(dec.17/003)",
+                "employment contracts",
+            )
+            .when(
+                lower(col("econ2"))
+                == "27 serv. para mant., reparaciones menores y limpieza",
+                "recurrent maintenance",
+            )
+            .when(
+                (
+                    (col("year") < 2020)
+                    & (
+                        lower(col("econ2"))
+                        == "52 transferencias corrientes al sector privado"
+                    )
+                    | (
+                        lower(col("econ2"))
+                        == "54 transferencias de capital al sector privado"
+                    )
+                    | (
+                        lower(col("econ2"))
+                        == "04 transferencias de capital al sector privado"
+                    )
+                    | (
+                        lower(col("econ2"))
+                        == "02 transferencias corrientes al sector privado"
+                    )
+                ),
+                "subsidies to production",
+            )
+            .when(
+                (col("year") >= 2020)
+                & (
+                    (
+                        lower(col("econ2"))
+                        == "04 transferencias de capital al sector privado"
+                    )
+                    | (
+                        lower(col("econ2"))
+                        == "02 transferencias corrientes al sector privado"
+                    )
+                ),
+                "subsidies to production",
+            )
+            .when(
+                col("func1").startswith("11 ")
+                & col("func2").startswith("0402")
+                & col("econ1").startswith("5 "),
+                "pensions",
+            )
+            .when(
+                col("func1").startswith("11 ") & col("econ1").startswith("5 "),
+                "social assistance",
+            ),
+        )
+        .withColumn(
+            "econ",
+            when(col("econ1").startswith("6 "), "Interest on debt")
+            .when(col("exp_type") == "Personal", "Wage bill")
+            .when(col("exp_type") == "Inversion", "Capital expenditures")
+            .when(
+                col("econ1").startswith("1 ")
+                | col("econ1").startswith("2 ")
+                | ((col("econ1").startswith("3 ")) & (col("exp_type") == "Inversion")),
+                "Goods and services",
+            )
+            .when(
+                (
+                    (col("year") < 2020)
+                    & (
+                        lower(col("econ2"))
+                        == "52 transferencias corrientes al sector privado"
+                    )
+                    | (
+                        lower(col("econ2"))
+                        == "54 transferencias de capital al sector privado"
+                    )
+                    | (
+                        lower(col("econ2"))
+                        == "04 transferencias de capital al sector privado"
+                    )
+                    | (
+                        lower(col("econ2"))
+                        == "02 transferencias corrientes al sector privado"
+                    )
+                ),
+                "Subsidies",
+            )
+            .when(
+                (
+                    (col("year") >= 2020)
+                    & (
+                        (
+                            lower(col("econ2"))
+                            == "04 transferencias de capital al sector privado"
+                        )
+                        | (
+                            lower(col("econ2"))
+                            == "02 transferencias corrientes al sector privado"
+                        )
+                    )
+                ),
+                "Subsidies",
+            )
+            .when(
+                col("econ_sub").isin("pensions", "social assistance"), "Social benefits"
+            )
+            .when(
+                (
+                    lower(col("econ2"))
+                    == "01 transferencias corrientes al sector publico"
+                )
+                | (
+                    lower(col("econ2"))
+                    == "51 transferencias corrientes al sector publico"
+                )
+                & ~col("func1").startswith("11 "),
+                "Grants and transfers",
+            )
+            .otherwise("Other expenses"),
+        )
     )
 
+
+@dlt.table(name=f"ury_boost_gold")
+def boost_gold():
+    return (
+        dlt.read(f"ury_boost_silver")
+        .withColumn("country_name", lit(COUNTRY))
+        .select(
+            "country_name",
+            "year",
+            "approved",
+            "executed",
+            "is_foreign",
+            "geo1",
+            "admin0",
+            "admin1",
+            "admin2",
+            "func_sub",
+            "func",
+            "econ_sub",
+            "econ",
+        )
+    )

--- a/Uruguay/URY_transform_load_dlt.py.py
+++ b/Uruguay/URY_transform_load_dlt.py.py
@@ -46,6 +46,7 @@ def boost_bronze():
 def boost_silver():
     return (
         dlt.read(f"ury_boost_bronze")
+        .withColumn("econ2_lower", lower(col("econ2")))
         .withColumn("admin0", lit("Central"))  # No subnational data available
         .withColumn("geo1", lit("Central"))  # No subnational data available
         .withColumn("is_foreign", col("SOURCE_FIN1").startswith("20 "))
@@ -141,11 +142,10 @@ def boost_silver():
             "econ_sub",
             when(
                 (col("exp_type") == "Personal")
-                & (lower(col("econ2")) != "06 beneficios al personal")
-                & (lower(col("econ2")) != "07 beneficios familiares")
+                & (col("econ2_lower") != "06 beneficios al personal")
+                & (col("econ2_lower") != "07 beneficios familiares")
                 & (
-                    lower(col("econ2"))
-                    != "08 cargas legales sobre servicios personales"
+                    col("econ2_lower") != "08 cargas legales sobre servicios personales"
                 ),
                 "basic wages",
             )
@@ -154,14 +154,14 @@ def boost_silver():
                 (col("exp_type") == "Inversion") & col("source_fin1").startswith("20 "),
                 "capital expenditure (foreign spending)",
             )
-            .when(lower(col("econ2")) == "21 servicios basicos", "basic services")
+            .when(col("econ2_lower") == "21 servicios basicos", "basic services")
             .when(
-                lower(col("econ2"))
+                col("econ2_lower")
                 == "28 servicios tecnicos, profesionales y artisticos(dec.17/003)",
                 "employment contracts",
             )
             .when(
-                lower(col("econ2"))
+                col("econ2_lower")
                 == "27 serv. para mant., reparaciones menores y limpieza",
                 "recurrent maintenance",
             )
@@ -169,19 +169,19 @@ def boost_silver():
                 (
                     (col("year") < 2020)
                     & (
-                        lower(col("econ2"))
+                        col("econ2_lower")
                         == "52 transferencias corrientes al sector privado"
                     )
                     | (
-                        lower(col("econ2"))
+                        col("econ2_lower")
                         == "54 transferencias de capital al sector privado"
                     )
                     | (
-                        lower(col("econ2"))
+                        col("econ2_lower")
                         == "04 transferencias de capital al sector privado"
                     )
                     | (
-                        lower(col("econ2"))
+                        col("econ2_lower")
                         == "02 transferencias corrientes al sector privado"
                     )
                 ),
@@ -191,11 +191,11 @@ def boost_silver():
                 (col("year") >= 2020)
                 & (
                     (
-                        lower(col("econ2"))
+                        col("econ2_lower")
                         == "04 transferencias de capital al sector privado"
                     )
                     | (
-                        lower(col("econ2"))
+                        col("econ2_lower")
                         == "02 transferencias corrientes al sector privado"
                     )
                 ),
@@ -227,19 +227,19 @@ def boost_silver():
                 (
                     (col("year") < 2020)
                     & (
-                        lower(col("econ2"))
+                        col("econ2_lower")
                         == "52 transferencias corrientes al sector privado"
                     )
                     | (
-                        lower(col("econ2"))
+                        col("econ2_lower")
                         == "54 transferencias de capital al sector privado"
                     )
                     | (
-                        lower(col("econ2"))
+                        col("econ2_lower")
                         == "04 transferencias de capital al sector privado"
                     )
                     | (
-                        lower(col("econ2"))
+                        col("econ2_lower")
                         == "02 transferencias corrientes al sector privado"
                     )
                 ),
@@ -250,11 +250,11 @@ def boost_silver():
                     (col("year") >= 2020)
                     & (
                         (
-                            lower(col("econ2"))
+                            col("econ2_lower")
                             == "04 transferencias de capital al sector privado"
                         )
                         | (
-                            lower(col("econ2"))
+                            col("econ2_lower")
                             == "02 transferencias corrientes al sector privado"
                         )
                     )
@@ -265,12 +265,9 @@ def boost_silver():
                 col("econ_sub").isin("pensions", "social assistance"), "Social benefits"
             )
             .when(
-                (
-                    lower(col("econ2"))
-                    == "01 transferencias corrientes al sector publico"
-                )
+                (col("econ2_lower") == "01 transferencias corrientes al sector publico")
                 | (
-                    lower(col("econ2"))
+                    col("econ2_lower")
                     == "51 transferencias corrientes al sector publico"
                 )
                 & ~col("func1").startswith("11 "),

--- a/Uruguay/URY_transform_load_dlt.py.py
+++ b/Uruguay/URY_transform_load_dlt.py.py
@@ -1,5 +1,4 @@
 # Databricks notebook source
-# Databricks notebook source
 import dlt
 import unicodedata
 from pyspark.sql.functions import substring, col, lit, when, udf, trim, regexp_replace, initcap, concat
@@ -63,14 +62,14 @@ def boost_silver():
                         .when(col('func1').startswith('11 '), 'Social protection')
                         .otherwise('General public services'))
             .withColumn('econ_sub',
-                        when((col('exp_type') == "Personal") & ~col('econ2').startswith('06 ') & ~col('econ2').startswith('07 ') &  ~col('econ2').startswith('08 '), 'basic wages')
+                        when((col('exp_type') == "Personal") & (col('econ2') != '06 Beneficios al personal') & (col('econ2') != '07 Beneficios familiares",econ2') & ( col('econ2') != '08 Cargas legales sobre servicios personales'), 'basic wages')
                         .when(col('exp_type') == "Personal", "allowances")
                         .when((col('exp_type')=="Inversion") & col('source_fin1').startswith('20 '), 'capital expenditure (foreign spending)')
-                        .when(col('econ2').startswith('21 '), 'basic services')
-                        .when(col('econ2').startswith('28 '), 'employment contracts')
-                        .when(col('econ2').startswith('27 '), 'recurrent maintenance')
-                        .when((col("year") < 2020) & ((col('econ2').startswith('52 ')) | (col('econ2').startswith('54')) | (col('econ2').startswith('04 ')) | (col('econ2').startswith('02 '))), 'subsidies to production')
-                        .when((col("year") >= 2020) & ((col('econ2').startswith('04 ')) | (col('econ2').startswith('02 '))), 'subsidies to production')
+                        .when(col('econ2') == '21 Servicios basicos', 'basic services')
+                        .when(col('econ2') == '28 Servicios tecnicos, profesionales y artisticos(Dec.17/003)', 'employment contracts')
+                        .when(col('econ2').startswith('27 Serv. para mant., reparaciones menores y limpieza'), 'recurrent maintenance')
+                        .when((col("year") < 2020) & ((col('econ2') == '52 Transferencias corrientes al sector privado') | (col('econ2') == '54 Transferencias de capital al sector privado') | (col('econ2') == '04 Transferencias De Capital Al Sector Privado') | (col('econ2') == '02 Transferencias Corrientes Al Sector Privado')), 'subsidies to production')
+                        .when((col("year") >= 2020) & ((col('econ2') == '04 Transferencias De Capital Al Sector Privado') | (col('econ2') == '02 Transferencias Corrientes Al Sector Privado')), 'subsidies to production')
                         .when(col('func1').startswith('11 ') & col('func2').startswith('0402') & col('econ1').startswith('5 '), 'pensions')
                         .when(col('func1').startswith('11 ') & col('econ1').startswith('5 '), 'social assistance'))
             .withColumn('econ',
@@ -79,10 +78,10 @@ def boost_silver():
                         .when(col('exp_type') == 'Inversion','Capital expenditures')
                         .when(col('econ1').startswith('1 ') | col('econ1').startswith('2 ')| ((col('econ1').startswith('3 ')) &
                         (col('exp_type')=="Inversion")),'Goods and services')
-                        .when(((col("year") < 2020) & ((col('econ2').startswith('52 ')) | (col('econ2').startswith('54')) | (col('econ2').startswith('04 ')) | (col('econ2').startswith('02 ')))), 'Subsidies')
-                        .when(((col("year") >= 2020) & ((col('econ2').startswith('04 ')) | (col('econ2').startswith('02 ')))), 'Subsidies')
+                        .when(((col("year") < 2020) & ((col('econ2') == '52 Transferencias corrientes al sector privado') | (col('econ2') == '54 Transferencias de capital al sector privado' ) | (col('econ2') == '04 Transferencias De Capital Al Sector Privado') | (col('econ2') == '02 Transferencias Corrientes Al Sector Privado'))), 'Subsidies')
+                        .when(((col("year") >= 2020) & ((col('econ2')== '04 Transferencias De Capital Al Sector Privado') | (col('econ2') == '02 Transferencias Corrientes Al Sector Privado'))), 'Subsidies')
                         .when(col('econ_sub').isin('pensions', 'social assistance'), 'Social benefits')
-                        .when((col('econ2').startswith('01 ') | col('econ2').startswith('51 ')) & ~col('func1').startswith('11 '), 'Grants and transfers')
+                        .when((col('econ2') == '01 Transferencias Corrientes Al Sector Público ') | (col('econ2') == '51 Transferencias corrientes al sector público') & ~col('func1').startswith('11 '), 'Grants and transfers')
                         .otherwise('Other expenses'))
             )
 


### PR DESCRIPTION
There seems to be some issues with uruguay Econ2. 
1. Since each prefix number corresponds to differerent category, we canot use the prefix for the tag.
2. There are some issues with lower/upper letter consistencies in the BOOST dataset for ECON2.
![image](https://github.com/user-attachments/assets/33ecf2e2-1f9c-4143-9353-f08dc4c3f685)