### PR TITLE
Review & harmonize central scope across countries

### DIFF
--- a/Albania/ALB_transform_load_dlt.py
+++ b/Albania/ALB_transform_load_dlt.py
@@ -20,8 +20,7 @@ CSV_READ_OPTIONS = {
 
 @dlt.expect_or_drop("year_not_null", "YEAR IS NOT NULL")
 @dlt.table(name=f'alb_boost_bronze')
-def boost_bronze_cen():
-    # Load the data from CSV
+def boost_bronze():
     return (spark.read
             .format("csv")
             .options(**CSV_READ_OPTIONS)
@@ -37,12 +36,13 @@ def boost_silver():
             ).withColumn('admin0',
                         when(col('admin1')=='Local', 'Regional')
                         .otherwise('Central')                
+            ).withColumn('admin1',
+                        when(col('counties')=='Central', 'Central Scope')
+                        .otherwise(col('counties'))
             ).withColumn('admin2_tmp',
                         when(col('counties')=='Central', col('admin3'))
                         .otherwise(col('counties'))
-            ).withColumn('geo1',
-                        when(col('counties')=='Central', 'Central Scope')
-                        .otherwise(col('counties'))
+            ).withColumn('geo1', col('admin1')
             ).withColumn('func_sub',
                         # spending in judiciary
                         when(col('func2').startswith('033'), 'judiciary')
@@ -137,7 +137,7 @@ def boost_gold():
                 'is_foreign',
                 'geo1',
                 'admin0',
-                col('counties').alias('admin1'),
+                'admin1',
                 col('admin2_tmp').alias('admin2'),
                 'func_sub',
                 'func',

--- a/Albania/ALB_transform_load_dlt.py
+++ b/Albania/ALB_transform_load_dlt.py
@@ -33,10 +33,10 @@ def boost_silver():
     return (dlt.read(f'alb_boost_bronze')          
             .filter(col('transfer') == 'Excluding transfers'
             ).withColumn('is_foreign', col('fin_source').startswith('2')
-            ).withColumn('admin0',
-                        when(col('admin1')=='Local', 'Regional')
-                        .otherwise('Central')                
-            ).withColumn('admin1',
+            ).withColumn('admin0', 
+                when(col('admin2').startswith('00') | col('admin2').startswith('999'), 'Central')
+                .otherwise('Regional')    
+            ).withColumn('admin1_tmp',
                         when(col('counties')=='Central', 'Central Scope')
                         .otherwise(col('counties'))
             ).withColumn('admin2_tmp',
@@ -137,7 +137,7 @@ def boost_gold():
                 'is_foreign',
                 'geo1',
                 'admin0',
-                'admin1',
+                col('admin1_tmp').alias('admin1'),
                 col('admin2_tmp').alias('admin2'),
                 'func_sub',
                 'func',

--- a/Congo_DR/COD_transform_load_dlt.py
+++ b/Congo_DR/COD_transform_load_dlt.py
@@ -40,7 +40,7 @@ def boost_silver():
         .withColumn('is_interest', col('Titre') == "1 DETTE PUBLIQUE EN CAPITAL") # this is not interest need to rename it
         .withColumn('is_foreign', (col('Source').isin('Budget General_Externe', 'Externe') & (col('Article')!='12 Dette Exterieure')))
         .withColumn('admin0', lit('Central'))
-        .withColumn('admin1', lit('Central'))
+        .withColumn('admin1', lit('Central Scope'))
         .withColumn('admin2', initcap(regexp_replace(col('Chapitre'), '^[0-9\\s]*', '')))
         .withColumn('geo1',
             when(col("Province").startswith('00'), 'Central Scope')

--- a/Mozambique/transform_load_dlt.py
+++ b/Mozambique/transform_load_dlt.py
@@ -46,22 +46,15 @@ def boost_silver():
         .drop('Adm5')
         .select("*", col('Adm51').alias('Adm5'))
         .drop('Adm51', 'UGB_third')
-        .withColumn('adm1_name',
+        .withColumn('geo1',
             when(col("Adm5En") == "Maputo (city)", "Cidade de Maputo")
             .otherwise(
                 when(col("Adm5En") == "Central", "Central Scope")
                 .otherwise(col("Adm5En")))
-        ).withColumn('geo1',
-            when(col("Adm5En") == "Maputo (city)", "Cidade de Maputo")
-            .otherwise(
-                when(col("Adm5En") == "Central", "Central Scope")
-                .otherwise(col("Adm5En")))
-        ).withColumn( 'admin0',
+        ).withColumn('admin0',
             when(col('Adm5').startswith('A'), 'Central')
             .otherwise('Regional')
-        ).withColumn('admin1',
-            when(col("Adm5En") == "Maputo (city)", "Cidade de Maputo")
-            .otherwise(col("Adm5En"))
+        ).withColumn('admin1', col('geo1')
         ).withColumn('admin2',
             trim(regexp_replace(col("Adm2"), '^[0-9\\s]*', ''))
         ).withColumn('is_foreign', ~col('Fund1').startswith('1') # foreign funded expenditure
@@ -140,7 +133,6 @@ def boost_gold():
     return (dlt.read(f'moz_boost_silver')
         .withColumn('country_name', lit(COUNTRY))
         .select('country_name',
-                'adm1_name',
                 col('Year').alias('year'),
                 col('DotacaoInicial').alias('approved'),
                 col('DotacaoActualizada').alias('revised'),

--- a/Pakistan/PAK_transform_load_dlt.py
+++ b/Pakistan/PAK_transform_load_dlt.py
@@ -37,18 +37,13 @@ def boost_bronze():
 def boost_silver():
     return (dlt.read(f'pak_boost_bronze')
         .filter(~col('econ1').startswith('A08 ') & ~col('econ1').startswith('A10 ') & ~col('econ1').startswith('A99 '))
-        .withColumn('adm1_name',
-            when(col("Admin0") == "Federal", "Central Scope")
-            .otherwise(
-                when(col("Admin0") == "KP", "Khyber Pakhtunkhwa")
-                .otherwise(col("Admin0")))
-        ).withColumn(
+        .withColumn(
             'admin0_tmp', 
             when(col('Admin0')=='Federal', 'Central')
             .otherwise('Regional')
         ).withColumn(
             'admin1_tmp', # since admin1 already exists in the raw data
-            when(col('admin0_tmp')=='Central', 'Central')
+            when(col('admin0_tmp')=='Central', 'Central Scope')
             .when(col("Admin0") == "KP", 'Khyber Pakhtunkhwa')
             .otherwise(col('Admin0'))
         ).withColumn(
@@ -99,7 +94,7 @@ def boost_silver():
             # social benefits
             .when(col('econ_sub').isin('social assistance', 'pensions'), 'Social benefits')
             # other grants and transfers
-            .when((col('econ1').startswith('A05')) & (~col('func1').startswith('10')) & (~col('econ2').startswith('A051')), 'Grants and transfers')
+            .when((col('econ1').startswith('A05')) & (~col('func1').startswith('10')) & (~col('econ2').startswith('A051')), 'Other grants and transfers')
             # interest on debt
             .when(col('econ1').startswith('A07 '), 'Interest on debt') 
             .otherwise('Other expenses') 
@@ -111,7 +106,6 @@ def boost_gold():
     return (dlt.read(f'pak_boost_silver')
             .withColumn('country_name', lit(COUNTRY))
             .select('country_name',
-                    'adm1_name',
                     'year',
                     'approved',
                     expr("CAST(NULL AS DOUBLE) as revised"),

--- a/Tunisia/TUN_transform_load_dlt.py
+++ b/Tunisia/TUN_transform_load_dlt.py
@@ -43,15 +43,10 @@ def boost_silver():
             .withColumn('Maintenance',coalesce(col('Maintenance'), lit('')))
             .withColumn('subsidies',coalesce(col('subsidies'), lit('')))            
             .withColumn('Air',coalesce(col('Air'), lit('')))         
-            .withColumn('adm1_name', 
-                when(col("GEO1").isNull(), "Central Scope")
-                .when(col("GEO1").startswith("0") | col("GEO1").startswith("9"), "Other")
-                .when(col("GEO1").rlike('^[1-8]'), trim(regexp_replace(col("GEO1"), '^[1-8]+\\s*', '')))
-                )            
         ).withColumn(
         'admin0_tmp', lit('Central')
         ).withColumn(
-        'admin1_tmp', lit('Central')
+        'admin1_tmp', lit('Central Scope')
         ).withColumn(
         'admin2_tmp', trim(regexp_replace(col("ADMIN2"), '^[0-9\\s]*', ''))
         ).withColumn(
@@ -125,7 +120,6 @@ def boost_gold():
             .filter(~col('ECON2').startswith('10')) # debt repayment
             .withColumn('country_name', lit('Tunisia')) 
             .select('country_name',
-                    'adm1_name',
                     col('YEAR').alias('year'),
                     col('OUVERT').alias('approved'),
                     col('ORDONNANCE').alias('revised'),

--- a/Uruguay/URY_transform_load_dlt.py.py
+++ b/Uruguay/URY_transform_load_dlt.py.py
@@ -48,7 +48,7 @@ def boost_silver():
         dlt.read(f"ury_boost_bronze")
         .withColumn("econ2_lower", lower(col("econ2")))
         .withColumn("admin0", lit("Central"))  # No subnational data available
-        .withColumn("geo1", lit("Central"))  # No subnational data available
+        .withColumn("geo1", lit("Central Scope"))  # No subnational data available
         .withColumn("is_foreign", col("SOURCE_FIN1").startswith("20 "))
         .withColumn(
             "func_sub",
@@ -271,7 +271,7 @@ def boost_silver():
                     == "51 transferencias corrientes al sector publico"
                 )
                 & ~col("func1").startswith("11 "),
-                "Grants and transfers",
+                "Other grants and transfers",
             )
             .otherwise("Other expenses"),
         )
@@ -283,6 +283,8 @@ def boost_gold():
     return (
         dlt.read(f"ury_boost_silver")
         .withColumn("country_name", lit(COUNTRY))
+        .withColumn("admin2", col("admin1"))
+        .withColumn("admin1", lit("Central Scope"))
         .select(
             "country_name",
             "year",


### PR DESCRIPTION
For admin1 and geo1 it should always be "Central Scope", while admin0 says "Central". 
Also clean up adm1_name definitions.

@yukinko-iwasaki kindly review changes made to Uruguay and let me know if there's any comments/feedback.
@bhupatiraju please do the same for the rest of the countries. 
Some changes may change the tagging – in principle I'm putting anything not tied to a specific geo region to central scope, and anything not tagged or tagged "other" I'm putting them with the "catch-all" categories such as general public services.

This change set is meant to fix all the failed quality checks currently in the agg pipeline (with additional checks added in https://github.com/dime-worldbank/mega-boost/commit/df095567afb187ae6db60181ce81588533bfdd0a#diff-1591dbadbc2ba5a02ba67f6793efc1e53a2724db98f33e0c8950f224a679599f