### PR TITLE
EXPERIMENTAL: introduce constant variables

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class ECON_TYPES(Enum):
+    CAPITAL_EXPENDITURES = "Capital expenditures"
+    GOODS_AND_SERVICES = "Goods and services"
+    INTEREST_ON_DEBT = "Interest on debt"
+    OTHER_EXPENSES = "Other expenses"
+    OTHER_GRANTS_AND_TRANSFERS = "Other grants and transfers"
+    SOCIAL_BENEFITS = "Social benefits"
+    SUBSIDIES = "Subsidies"
+    WAGE_BILL = "Wage bill"


### PR DESCRIPTION
This PR attempts to 
1. Introduce custom class for keeping track of econ tagging constants. 
- The DataBricks seems to require full path to be added to the system before importing a module 
e.g. `Workspace/Users/ysuzuki2@worldbank.org/mega-boost`. I had some issue extracting the username(email) in dlt notebook. The code looks a bit messy, let me know if you know of a cleaner way to extracting the path. 

2. Use of constant variable instead of literal for econ taggings. This is currently applied for Uruguay's Econ tagging. If this seems to be a viable solution, let's extend this approach to other countries/other taggings.

@weilu @bhupatiraju Could you try if this solution works on your workspace. I could only confirm that it works on my workspace. 