### PR TITLE
Fix uruguay discrepancies

### DIFF
--- a/Uruguay/URY_transform_load_dlt.py
+++ b/Uruguay/URY_transform_load_dlt.py
@@ -138,7 +138,17 @@ def boost_silver():
             .when(col("func1").startswith("13 "), "Health")
             .when(col("func1").startswith("05 "), "Recreation, culture and religion")
             .when(col("func1").startswith("08 "), "Education")
-            .when(col("func1").startswith("11 "), "Social protection")
+            .when(
+                ((col("year") < 2020) & (col("func1").startswith("11 ")))
+                | (
+                    (col("year") >= 2020)
+                    & (
+                        (col("func1").startswith("19 "))
+                        | (col("func1").startswith("20 "))
+                    )
+                ),
+                "Social protection",
+            )
             .otherwise("General public services"),
         )
         .withColumn(
@@ -154,7 +164,8 @@ def boost_silver():
             )
             .when(col("exp_type") == "Personal", "allowances")
             .when(
-                (col("exp_type") == "Inversion") & col("source_fin1").startswith("20 "),
+                (lower(col("exp_type")) == "inversion")
+                & col("source_fin1").startswith("20 "),
                 "capital expenditure (foreign spending)",
             )
             .when(col("econ2_lower") == "21 servicios basicos", "basic services")
@@ -221,7 +232,7 @@ def boost_silver():
             .when(col("exp_type") == "Personal", "Wage bill")
             .when(
                 (
-                    (col("exp_type") == "Inversion")
+                    (lower(col("exp_type")) == "inversion")
                     & (
                         col("econ2_lower")
                         != "02 transferencias corrientes al sector privado"

--- a/Uruguay/URY_transform_load_dlt.py
+++ b/Uruguay/URY_transform_load_dlt.py
@@ -46,7 +46,6 @@ def boost_bronze():
 def boost_silver():
     return (
         dlt.read(f"ury_boost_bronze")
-        .withColumn("id", monotonically_increasing_id())
         .withColumn("econ2_lower", lower(col("econ2")))
         .withColumn("admin0", lit("Central"))  # No subnational data available
         .withColumn("geo1", lit("Central Scope"))  # No subnational data available

--- a/Uruguay/URY_transform_load_dlt.py
+++ b/Uruguay/URY_transform_load_dlt.py
@@ -14,7 +14,6 @@ from pyspark.sql.functions import (
     lower,
 )
 from pyspark.sql.types import StringType
-from pyspark.sql.functions import monotonically_increasing_id
 
 # Note DLT requires the path to not start with /dbfs
 TOP_DIR = "/mnt/DAP/data/BOOSTProcessed"
@@ -40,7 +39,6 @@ def boost_bronze():
         .options(**CSV_READ_OPTIONS)
         .option("inferSchema", "true")
         .load(f"{COUNTRY_MICRODATA_DIR}")
-        .withColumn("id", monotonically_increasing_id())
     )
 
 
@@ -318,7 +316,6 @@ def boost_gold():
         .withColumn("admin2", col("admin1"))
         .withColumn("admin1", lit("Central Scope"))
         .select(
-            "id",
             "country_name",
             "year",
             "approved",


### PR DESCRIPTION
The func = "Social Protection" was missing for the years 2020, 2021, 2022. 
I missed that the formula was different for those years. 

Since this func tag was missing for these years in our MEGA version of the datasets, in our quality check dashboard,  this only showed up as a discrepancy in "General Public Services" (otherwise condition).
I think it would be more straightforward to display this as a discrepancy in "Social Protection" for debugging purposes. 

How do you feel about modifying our query for the func [discrepancy table](https://adb-6102124407836814.14.azuredatabricks.net/sql/dashboardsv3/01ef07bf07d615bb98b5ff5b37e6fa69/datasets/01ef07bf07da1c1e8c17bb54b5975e14?o=6102124407836814) to the following so that we do not ignore the missing func tags in our discrepancy quality table?. 

```sql
SELECT q.country_name, q.func, q.year,  COALESCE(e.expenditure,0) as mega_expenditure, COALESCE(q.amount,0) as cci_expenditure, 
    round((mega_expenditure - amount)/amount * 100, 4) as percent_diff,
    abs((mega_expenditure - amount)/amount * 100) as percent_diff_abs,
    e.central_expenditure, e.decentralized_expenditure
FROM boost.expenditure_by_country_func_year e
RIGHT JOIN boost_intermediate.quality_functional_silver q
    ON e.country_name = q.country_name AND e.func = q.func and e.year = q.year
WHERE (q.approved_or_executed = 'Executed' or q.approved_or_executed is null) and q.country_name = "Uruguay" and q.year = 2020
ORDER BY 1, 2, 3
```
Summary of suggested changes to discrepancy table.
1. Left Join => Right Join (we can assume that our discrepancy is based on the CCI tables against our MEGA table?)
2. fill the null values to 0 (coalesce)


