### PR TITLE
Prepare boost_gold for internal publishing

### DIFF
--- a/Mozambique/transform_load_dlt.py
+++ b/Mozambique/transform_load_dlt.py
@@ -46,6 +46,9 @@ def boost_silver():
         .drop('Adm5')
         .select("*", col('Adm51').alias('Adm5'))
         .drop('Adm51', 'UGB_third')
+        .withColumn('DotacaoInicial', col('DotacaoInicial').cast('double'))
+        .withColumn('DotacaoActualizada', col('DotacaoActualizada').cast('double'))
+        .withColumn('Execution', col('Execution').cast('double'))
         .withColumn('geo1',
             when(col("Adm5En") == "Maputo (city)", "Cidade de Maputo")
             .otherwise(

--- a/Tunisia/TUN_transform_load_dlt.py
+++ b/Tunisia/TUN_transform_load_dlt.py
@@ -42,7 +42,8 @@ def boost_silver():
             .withColumn('railroads',coalesce(col('railroads'), lit('')))
             .withColumn('Maintenance',coalesce(col('Maintenance'), lit('')))
             .withColumn('subsidies',coalesce(col('subsidies'), lit('')))            
-            .withColumn('Air',coalesce(col('Air'), lit('')))         
+            .withColumn('Air',coalesce(col('Air'), lit('')))
+            .withColumn('year', col('YEAR').cast('int'))        
         ).withColumn(
         'admin0_tmp', lit('Central')
         ).withColumn(
@@ -124,7 +125,7 @@ def boost_gold():
             .filter(~col('ECON2').startswith('10')) # debt repayment
             .withColumn('country_name', lit('Tunisia')) 
             .select('country_name',
-                    col('YEAR').alias('year'),
+                    'year',
                     col('OUVERT').alias('approved'),
                     col('ORDONNANCE').alias('revised'),
                     col('PAYE').alias('executed'),

--- a/Uruguay/URY_transform_load_dlt.py
+++ b/Uruguay/URY_transform_load_dlt.py
@@ -46,6 +46,9 @@ def boost_bronze():
 def boost_silver():
     return (
         dlt.read(f"ury_boost_bronze")
+        .withColumn('year', col('year').cast('int'))
+        .withColumn('approved', col('approved').cast('double'))
+        .withColumn('executed', col('executed').cast('double'))
         .withColumn("econ2_lower", lower(col("econ2")))
         .withColumn("admin0", lit("Central"))  # No subnational data available
         .withColumn("geo1", lit("Central Scope"))  # No subnational data available

--- a/cross_country_aggregate_dlt.py
+++ b/cross_country_aggregate_dlt.py
@@ -2,11 +2,34 @@
 import dlt
 from pyspark.sql import functions as F
 from pyspark.sql.window import Window
+from pyspark.sql.types import StructType, StructField, StringType, IntegerType, DoubleType, BooleanType
 
 # Adding a new country requires adding the country here
 country_codes = ['moz', 'pry', 'ken', 'pak', 'bfa', 'col', 'cod', 'nga', 'tun', 'btn', 'bgd', 'alb', 'ury']
 
-@dlt.table(name=f'boost_gold')
+schema = StructType([
+    StructField("country_name", StringType(), True, {'comment': 'The name of the country for which the budget data is recorded (e.g., "Kenya", "Brazil").'}),
+    StructField("year", IntegerType(), True, {'comment': 'The fiscal year for the budget data (e.g., 2023, 2024).'}),
+    StructField("adm1_name", StringType(), True, {'comment': 'Alias for admin1 to denote first sub-national administrative level where money was spent.'}),
+    StructField("admin0", StringType(), True, {'comment': 'Who spent the money at the highest administrative level (either "Central" or "Regional").'}),
+    StructField("admin1", StringType(), True, {'comment': 'Who spent the money at the first sub-national administrative level (e.g., state or province name).'}),
+    StructField("admin2", StringType(), True, {'comment': 'Who spent the money at the second sub-national administrative level (e.g., government agency/ministry name or district).'}),
+    StructField("geo1", StringType(), True, {'comment': 'Geographically, at which first sub-national administrative level the money was spent.'}),
+    StructField("func", StringType(), True, {'comment': 'Functional classification of the budget (e.g., Health, Education).'}),
+    StructField("func_sub", StringType(), True, {'comment': 'Sub-functional classification under the main COFOG function (e.g., primary education, secondary education).'}),
+    StructField("econ", StringType(), True, {'comment': 'Economic classification of the budget (e.g., Wage bill, Goods and services).'}),
+    StructField("econ_sub", StringType(), True, {'comment': 'Sub-economic classification under the main economic category (e.g., basic wages, allowances).'}),
+    StructField("is_foreign", BooleanType(), True, {'comment': 'Indicator whether the expenditure is foreign funded or not.'}),
+    StructField("approved", DoubleType(), True, {'comment': 'Amount of budget in current local currency approved by the relevant authority.'}),
+    StructField("revised", DoubleType(), True, {'comment': 'Revised budget in current local currency amount during the fiscal year.'}),
+    StructField("executed", DoubleType(), True, {'comment': 'Actual amount spent in current local currency by the end of the fiscal year.'})
+])
+
+@dlt.table(
+    name='boost_gold',
+    comment="This dataset includes BOOST budget and expenditure data for multiple countries across various years, with information presented at the most granular level possible to ensure maximum analytical flexibility. Each entry is harmonized to include standardized labels for common BOOST features, such as functional and economic categories.",
+    schema=schema
+)
 def boost_gold():
     unioned_df = None
     for code in country_codes:

--- a/publish.sql
+++ b/publish.sql
@@ -1,0 +1,13 @@
+-- Databricks notebook source
+ALTER TABLE
+  prd_mega.boost.boost_gold
+SET
+  TAGS (
+    'subject' = 'Finance',
+    'classification' = 'Official Use Only',
+    'category' = 'Public Sector',
+    'subcategory' = 'Financial Management',
+    'frequency' = 'Annually',
+    'collection' = 'Financial Management (FM)',
+    'source' = 'BOOST'
+  )


### PR DESCRIPTION
by adding table and column comments, standardizing data types, and adding required table tags.

@bhupatiraju @yukinko-iwasaki I created a new DLT workflow "BOOST Agg UC" which I added both you to. It publishes the agg resulting data into UC instead of hive_metastore. This is necessary for the publishing to corporate data catalog workflow. I think it's ok to keep the upstream data in hive_metastore for now. I will update the discrepancy dashboard to read from the UC boost tables before deleting the hive_metastore boost tables.