### PR TITLE
Update Uruguay econ/econ_sub tagging and fix agg pipeline

### DIFF
--- a/Uruguay/URY_transform_load_dlt.py
+++ b/Uruguay/URY_transform_load_dlt.py
@@ -45,9 +45,9 @@ def boost_bronze():
 def boost_silver():
     return (
         dlt.read(f"ury_boost_bronze")
-        .withColumn('year', col('year').cast('int'))
-        .withColumn('approved', col('approved').cast('double'))
-        .withColumn('executed', col('executed').cast('double'))
+        .withColumn("year", col("year").cast("int"))
+        .withColumn("approved", col("approved").cast("double"))
+        .withColumn("executed", col("executed").cast("double"))
         .withColumn("econ2_lower", lower(col("econ2")))
         .withColumn("exp_type_lower", lower(col("exp_type")))
         .withColumn("admin0", lit("Central"))  # No subnational data available
@@ -217,7 +217,7 @@ def boost_silver():
             .when(col("econ2_lower") == "21 servicios basicos", "Basic Services")
             .when(
                 (
-                    (col("year") < 2019)
+                    ((col("year") < 2019) | (col("year") >= 2023))
                     & (
                         col("econ2_lower")
                         == "28 servicios tecnicos, profesionales y artisticos(dec.17/003)"
@@ -326,37 +326,45 @@ def boost_silver():
             )
             .when(
                 (
-                    (col("year") < 2020)
+                    (col("year") <= 2019)
                     & (
-                        col("econ2_lower")
-                        == "52 transferencias corrientes al sector privado"
+                        col("econ2_lower").startswith("52 ")
                     )
                     | (
-                        col("econ2_lower")
-                        == "54 transferencias de capital al sector privado"
+                        col("econ2_lower").startswith("54 ")
                     )
                     | (
-                        col("econ2_lower")
-                        == "04 transferencias de capital al sector privado"
+                        col("econ2_lower").startswith("04 ")
                     )
                     | (
-                        col("econ2_lower")
-                        == "02 transferencias corrientes al sector privado"
+                        col("econ2_lower").startswith("02 ")
                     )
                 ),
                 "Subsidies",
             )
             .when(
                 (
-                    (col("year") >= 2020)
+                    ((col("year") < 2023) | (col("year") > 2019))
                     & (
                         (
-                            col("econ2_lower")
-                            == "04 transferencias de capital al sector privado"
+                            col("econ2_lower").startswith("02 ")
                         )
                         | (
-                            col("econ2_lower")
-                            == "02 transferencias corrientes al sector privado"
+                            col("econ2_lower").startswith("04 ")
+                        )
+                    )
+                ),
+                "Subsidies",
+            )
+            .when(
+                (
+                    (col("year") >= 2023)
+                    & (
+                        (
+                            col("econ2_lower").startswith("52 ")
+                        )
+                        | (
+                            col("econ2_lower").startswith("54 ")
                         )
                     )
                 ),

--- a/quality/transform_load_dlt.py
+++ b/quality/transform_load_dlt.py
@@ -44,7 +44,7 @@ def quality_total_silver():
     bronze = dlt.read('quality_cci_bronze')
     year_cols = list(col_name for col_name in bronze.columns if col_name.isnumeric())
     return (bronze
-        .filter(F.col('category') == 'Spending: Total Expenditures')
+        .filter(F.trim(F.col('category')) == 'Spending: Total Expenditures')
         .melt(ids=["country_name", "approved_or_executed"], 
             values=year_cols, 
             variableColumnName="year", 


### PR DESCRIPTION
Summary of changes
1. Fix Uruguay econ and econ_sub for the year 2023
2. Fix the year range for the agg tables for latest_year to reflect the coverage on the actual agg output table.

The current agg table reflect the earliest latest year on the expenditure data. However, after the join with CPI and population, this might not be true for the output tables.

